### PR TITLE
topo for bwmf

### DIFF
--- a/.script/test
+++ b/.script/test
@@ -55,3 +55,4 @@ go test -v ./framework
 go test -v ./integration
 go test -v ./op
 go test -v ./filesystem
+go test -v ./example/topo

--- a/example/topo/full_topo.go
+++ b/example/topo/full_topo.go
@@ -5,44 +5,32 @@ package topo
 //
 //Also the star structure stays the same between epochs.
 type FullTopology struct {
-	numOfTasks        uint64
-	taskID            uint64
-	parents, children []uint64
+	numOfTasks uint64
+	taskID     uint64
+	neighbors  []uint64
 }
 
 // TODO, do we really need to expose this? Ideally after proper construction of StarTopology
 // we should not need to set this again.
 func (t *FullTopology) SetTaskID(taskID uint64) {
 	t.taskID = taskID
-
-	// each task is parent of every else.
-	t.parents = make([]uint64, 0, t.numOfTasks-1)
-	for index := uint64(1); index < t.numOfTasks; index++ {
+	t.neighbors = make([]uint64, 0, t.numOfTasks-1)
+	for index := uint64(0); index < t.numOfTasks; index++ {
 		if index != t.taskID {
-			t.parents = append(t.parents, index)
+			t.neighbors = append(t.neighbors, index)
 		}
 	}
-
-	t.children = make([]uint64, 0, t.numOfTasks-1)
-	for index := uint64(1); index < t.numOfTasks; index++ {
-		if index != t.taskID {
-			t.children = append(t.children, index)
-		}
-	}
-
 }
 
 func (t *FullTopology) GetLinkTypes() []string {
-	return []string{"Parents", "Children"}
+	return []string{"Neighbors"}
 }
 
 func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
 	res := make([]uint64, 0)
 	switch {
-	case linkType == "Parents":
-		res = t.parents
-	case linkType == "Children":
-		res = t.children
+	case linkType == "Neighbors":
+		res = t.neighbors
 	}
 	return res
 }

--- a/example/topo/full_topo.go
+++ b/example/topo/full_topo.go
@@ -1,7 +1,7 @@
 package topo
 
 //The full structure is basically assume that every one is also parent for every else.
-//And everyone else is communicating to get the data they need.
+//And everyone else is communicating to get the data they need. Task 0 is forced/assumed to be the master.
 //
 //Also the star structure stays the same between epochs.
 type FullTopology struct {
@@ -23,7 +23,7 @@ func (t *FullTopology) SetTaskID(taskID uint64) {
 }
 
 func (t *FullTopology) GetLinkTypes() []string {
-	return []string{"Neighbors"}
+	return []string{"Neighbors", "toMaster"}
 }
 
 func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
@@ -31,6 +31,8 @@ func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
 	switch {
 	case linkType == "Neighbors":
 		res = t.neighbors
+	case linkType == "toMaster":
+		res = []uint64{0}
 	}
 	return res
 }

--- a/example/topo/full_topo_test.go
+++ b/example/topo/full_topo_test.go
@@ -1,0 +1,27 @@
+package topo
+
+import (
+	"testing"
+)
+
+func TestFullTopogoly(t *testing.T) {
+	topo := NewFullTopology(3)
+
+	topo.SetTaskID(1)
+
+	if topo.numOfTasks != 3 {
+		t.Error()
+	}
+	if topo.taskID != 1 {
+		t.Error()
+	}
+	if len(topo.neighbors) != 2 {
+		t.Error()
+	}
+	if topo.neighbors[0] != 0 {
+		t.Error()
+	}
+	if topo.neighbors[1] != 2 {
+		t.Error()
+	}
+}

--- a/example/topo/full_topo_test.go
+++ b/example/topo/full_topo_test.go
@@ -15,13 +15,21 @@ func TestFullTopogoly(t *testing.T) {
 	if topo.taskID != 1 {
 		t.Error()
 	}
-	if len(topo.neighbors) != 2 {
+	n := topo.GetNeighbors("Neighbors", 0)
+	if len(n) != 2 {
 		t.Error()
 	}
-	if topo.neighbors[0] != 0 {
+	if n[0] != 0 {
 		t.Error()
 	}
-	if topo.neighbors[1] != 2 {
+	if n[1] != 2 {
+		t.Error()
+	}
+	m := topo.GetNeighbors("toMaster", 0)
+	if len(m) != 1 {
+		t.Error()
+	}
+	if m[0] != 0 {
 		t.Error()
 	}
 }

--- a/example/topo/tree_topo_test.go
+++ b/example/topo/tree_topo_test.go
@@ -62,7 +62,7 @@ func testTreeTopology(fanout, number uint64, tests []treeTopoTest, t *testing.T)
 		treeTopology := NewTreeTopology(fanout, number)
 		treeTopology.SetTaskID(tt.id)
 
-		linkTypes := treeTopology.GetLinkTypes(0)
+		linkTypes := treeTopology.GetLinkTypes()
 		if len(linkTypes) != 2 {
 			t.Error()
 		}
@@ -73,7 +73,7 @@ func testTreeTopology(fanout, number uint64, tests []treeTopoTest, t *testing.T)
 			t.Error()
 		}
 
-		parents := treeTopology.GetLinks("Parents", 0)
+		parents := treeTopology.GetNeighbors("Parents", 0)
 		if len(parents) != len(tt.parents) {
 			t.Errorf("TreeTopology27 got wrong number of parents for %q", tt.id)
 		}
@@ -83,7 +83,7 @@ func testTreeTopology(fanout, number uint64, tests []treeTopoTest, t *testing.T)
 			}
 		}
 
-		children := treeTopology.GetLinks("Children", 0)
+		children := treeTopology.GetNeighbors("Children", 0)
 		if len(children) != len(tt.children) {
 			t.Errorf("TreeTopology27 got wrong number of children for %q", tt.id)
 		}


### PR DESCRIPTION
* There should be no parents/children in full topo, instead we have one link type "Neighbors" and "toMaster".
* We do not treat master specially in neighbors. Everybody is everybody's neighbor.