### PR TITLE
bwmf: remove ioconfig.BlockId

### DIFF
--- a/example/bwmf/bwmf_task.go
+++ b/example/bwmf/bwmf_task.go
@@ -102,8 +102,6 @@ func (t *bwmfTask) initData() {
 		t.logger.Panicf("Failed load columnShard. %s", csErr)
 	}
 
-	// set blockId as taskID
-	t.config.IOConf.BlockId = t.taskID
 	t.dims = &dimensions{
 		m: len(t.rowShard.Row),
 		n: len(t.columnShard.Row),
@@ -176,14 +174,14 @@ func (t *bwmfTask) Init(taskID uint64, framework taskgraph.Framework) {
 
 func (t *bwmfTask) getDShard() *pb.Response {
 	return &pb.Response{
-		BlockId: t.config.IOConf.BlockId,
+		BlockId: t.taskID,
 		Shard:   t.dShard,
 	}
 }
 
 func (t *bwmfTask) getTShard() *pb.Response {
 	return &pb.Response{
-		BlockId: t.config.IOConf.BlockId,
+		BlockId: t.taskID,
 		Shard:   t.tShard,
 	}
 }

--- a/example/bwmf/configs.go
+++ b/example/bwmf/configs.go
@@ -13,7 +13,6 @@ type optconfig struct {
 
 // xFs can be "local", ""
 type ioconfig struct {
-	BlockId uint64
 	IFs     string
 	IDPath  string
 	ITPath  string

--- a/example/bwmf/configs_test.go
+++ b/example/bwmf/configs_test.go
@@ -15,7 +15,6 @@ func TestParseDump(t *testing.T) {
 			GradTol: 1e-6,
 		},
 		IOConf: ioconfig{
-			BlockId: 0,
 			IFs:     "local",
 			IDPath:  "./row_shard.dat",
 			ITPath:  "./column_shard.dat",

--- a/integration/bwmf_test.go
+++ b/integration/bwmf_test.go
@@ -21,7 +21,7 @@ func TestBWMF(t *testing.T) {
 	tb := &bwmf.BWMFTaskBuilder{
 		NumOfTasks: numOfTasks,
 		NumIters:   4,
-		ConfBytes:  []byte(`{"OptConf":{"Sigma":0.01,"Alpha":1,"Beta":0.1,"GradTol":1e-06},"IOConf":{"BlockId":0,"IFs":"local","IDPath":"../example/bwmf/data/row_shard.dat","ITPath":"../example/bwmf/data/column_shard.dat","OFs":"local","ODPath":"../example/bwmf/data/dShard.dat","OTPath":"../example/bwmf/data/tShard.dat","HdfsConf":{}}}`),
+		ConfBytes:  []byte(`{"OptConf":{"Sigma":0.01,"Alpha":1,"Beta":0.1,"GradTol":1e-06},"IOConf":{"IFs":"local","IDPath":"../example/bwmf/data/row_shard.dat","ITPath":"../example/bwmf/data/column_shard.dat","OFs":"local","ODPath":"../example/bwmf/data/dShard.dat","OTPath":"../example/bwmf/data/tShard.dat","HdfsConf":{}}}`),
 		LatentDim:  2,
 	}
 	for i := uint64(0); i < numOfTasks; i++ {


### PR DESCRIPTION
`ioconfig.BlockId` is always set as taskId in initData(). It's better to remove
it from ioconfig struct, since it's not really configurable.