### PR TITLE
Remove unnecessary check of close points.

### DIFF
--- a/op/projected_gradient.go
+++ b/op/projected_gradient.go
@@ -57,9 +57,6 @@ func (pg *ProjectedGradient) Minimize(loss Function, stop StopCriteria, vec Para
 				alpha /= pg.beta
 				newPoint(stt, cdd, ovalgrad.gradient, alpha/pg.beta, pg.projector)
 				evaluate(loss, cdd, tvalgrad)
-				if pg.isTooClose(cdd, nxt) {
-					break
-				}
 			}
 		} else {
 			// Now we decrease alpha barely enough to make sufficient decrease
@@ -99,16 +96,6 @@ func (pg *ProjectedGradient) isGoodStep(owts, nwts Parameter, ovg, nvg *vgpair) 
 		sum += float64(ovg.gradient.Get(i) * (nwts.Get(i) - owts.Get(i)))
 	}
 	return valdiff <= pg.sigma*float32(sum)
-}
-
-func (pg *ProjectedGradient) isTooClose(owts, nwts Parameter) bool {
-	sum := float64(0)
-	for it := owts.IndexIterator(); it.Next(); {
-		i := it.Index()
-		diff := float64(owts.Get(i) - nwts.Get(i))
-		sum += diff * diff
-	}
-	return sum < 1e-16*float64(owts.IndexIterator().Size())
 }
 
 // This creates a new point based on current point, step size and gradient.


### PR DESCRIPTION
The `isTooClose` check should be removed. It is true only in the cases (1) grad is quite small (2) alpha is quite small. For (1), it satisfies stop criteria and we will break in `Done`; and for (2), we will continue increasing alpha there.