### PR TITLE
Revert "Remove unnecessary check of close points."

### DIFF
--- a/op/projected_gradient.go
+++ b/op/projected_gradient.go
@@ -57,6 +57,9 @@ func (pg *ProjectedGradient) Minimize(loss Function, stop StopCriteria, vec Para
 				alpha /= pg.beta
 				newPoint(stt, cdd, ovalgrad.gradient, alpha/pg.beta, pg.projector)
 				evaluate(loss, cdd, tvalgrad)
+				if pg.isTooClose(cdd, nxt) {
+					break
+				}
 			}
 		} else {
 			// Now we decrease alpha barely enough to make sufficient decrease
@@ -96,6 +99,16 @@ func (pg *ProjectedGradient) isGoodStep(owts, nwts Parameter, ovg, nvg *vgpair) 
 		sum += float64(ovg.gradient.Get(i) * (nwts.Get(i) - owts.Get(i)))
 	}
 	return valdiff <= pg.sigma*float32(sum)
+}
+
+func (pg *ProjectedGradient) isTooClose(owts, nwts Parameter) bool {
+	sum := float64(0)
+	for it := owts.IndexIterator(); it.Next(); {
+		i := it.Index()
+		diff := float64(owts.Get(i) - nwts.Get(i))
+		sum += diff * diff
+	}
+	return sum < 1e-16*float64(owts.IndexIterator().Size())
 }
 
 // This creates a new point based on current point, step size and gradient.


### PR DESCRIPTION
As @BaiGang mentioned in #72, there are some issues in the previous patch.

I found the projected gradient minimizer stuck in the loop around https://github.com/taskgraph/taskgraph/pull/72/files#diff-6278c4f7bc773fcab0aabe214708b980R59 .
