### PR TITLE
filesystem: Open file with O_WRONLY in OpenWriteCloser()

### DIFF
--- a/filesystem/local_fs.go
+++ b/filesystem/local_fs.go
@@ -29,7 +29,7 @@ func (c *localFSClient) OpenWriteCloser(name string) (io.WriteCloser, error) {
 		}
 		return f, nil
 	}
-	return os.Open(name)
+	return os.OpenFile(name, os.O_WRONLY, 0)
 }
 
 func (c *localFSClient) Exists(name string) (bool, error) {


### PR DESCRIPTION
Otherwise, I saw errors like `write ../example/bwmf/data/dShard.dat.0: bad file descriptor`.