### PR TITLE
pb files update && goprotobuf google code fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 _obj
 _test
 .tmp
+.dep
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.script/dep.sh
+++ b/.script/dep.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# For Go plugin update, please see:
+#   https://github.com/grpc/grpc-common/tree/master/go
+
 go get -u github.com/coreos/go-etcd/etcd
 go get -u github.com/colinmarc/hdfs
 go get -u golang.org/x/net/context

--- a/.script/test
+++ b/.script/test
@@ -49,6 +49,13 @@ else
   exit 1
 fi
 
+clean_test_files() {
+  rm	example/bwmf/data/dShard.dat.0
+  rm	example/bwmf/data/dShard.dat.1
+  rm	example/bwmf/data/tShard.dat.0
+  rm	example/bwmf/data/tShard.dat.1
+}
+
 # testing
 go test -v ./controller
 go test -v ./framework
@@ -57,3 +64,5 @@ go test -v ./op
 go test -v ./filesystem
 go test -v ./example/topo
 go test -v ./example/bwmf
+
+clean_test_files

--- a/.script/test
+++ b/.script/test
@@ -6,9 +6,16 @@ if [ ! -d ".tmp" ]; then
     mkdir .tmp
 fi
 
+clean_test_files() {
+  rm	example/bwmf/data/dShard.dat.0 > /dev/null 2>&1
+  rm	example/bwmf/data/dShard.dat.1 > /dev/null 2>&1
+  rm	example/bwmf/data/tShard.dat.0 > /dev/null 2>&1
+  rm	example/bwmf/data/tShard.dat.1 > /dev/null 2>&1
+}
 cleanup() {
   kill $(jobs -p) 2>/dev/null
   rm -r $ETCDTESTDIR
+  clean_test_files
 }
 # cleanup on any kind of exit
 trap "cleanup" SIGINT SIGTERM EXIT
@@ -49,13 +56,6 @@ else
   exit 1
 fi
 
-clean_test_files() {
-  rm	example/bwmf/data/dShard.dat.0
-  rm	example/bwmf/data/dShard.dat.1
-  rm	example/bwmf/data/tShard.dat.0
-  rm	example/bwmf/data/tShard.dat.1
-}
-
 # testing
 go test -v ./controller
 go test -v ./framework
@@ -64,5 +64,3 @@ go test -v ./op
 go test -v ./filesystem
 go test -v ./example/topo
 go test -v ./example/bwmf
-
-clean_test_files

--- a/.script/test
+++ b/.script/test
@@ -6,6 +6,16 @@ if [ ! -d ".tmp" ]; then
     mkdir .tmp
 fi
 
+# Fix current code.google.com/ path problem
+fix_google_code_goprotobuf() {
+  mkdir -p .dep/src/code.google.com/p
+  cd .dep/src/code.google.com/p
+  git clone https://github.com/golang/protobuf goprotobuf
+  cd ../../../..
+  export GOPATH=$GOPATH:$(pwd)/.dep/
+}
+fix_google_code_goprotobuf
+
 clean_test_files() {
   rm	example/bwmf/data/dShard.dat.0 > /dev/null 2>&1
   rm	example/bwmf/data/dShard.dat.1 > /dev/null 2>&1

--- a/example/bwmf/proto/bwmf.pb.go
+++ b/example/bwmf/proto/bwmf.pb.go
@@ -153,9 +153,9 @@ func RegisterBlockDataServer(s *grpc.Server, srv BlockDataServer) {
 	s.RegisterService(&_BlockData_serviceDesc, srv)
 }
 
-func _BlockData_GetTShard_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _BlockData_GetTShard_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Request)
-	if err := proto1.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(BlockDataServer).GetTShard(ctx, in)
@@ -165,9 +165,9 @@ func _BlockData_GetTShard_Handler(srv interface{}, ctx context.Context, buf []by
 	return out, nil
 }
 
-func _BlockData_GetDShard_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _BlockData_GetDShard_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Request)
-	if err := proto1.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(BlockDataServer).GetDShard(ctx, in)

--- a/example/regression/proto/regression.pb.go
+++ b/example/regression/proto/regression.pb.go
@@ -99,9 +99,9 @@ func RegisterRegressionServer(s *grpc.Server, srv RegressionServer) {
 	s.RegisterService(&_Regression_serviceDesc, srv)
 }
 
-func _Regression_GetParameter_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Regression_GetParameter_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Input)
-	if err := proto1.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(RegressionServer).GetParameter(ctx, in)
@@ -111,9 +111,9 @@ func _Regression_GetParameter_Handler(srv interface{}, ctx context.Context, buf 
 	return out, nil
 }
 
-func _Regression_GetGradient_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Regression_GetGradient_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Input)
-	if err := proto1.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(RegressionServer).GetGradient(ctx, in)


### PR DESCRIPTION
1. protobuf go plugin and grpc changes. Let's upgrade it.
2. the google code goprotobuf is moved to github. But the hdfs dep doesn't upgrade to it. I have a temporary fix to hack GOPATH and download repo manually.