### PR TITLE
Add 'set -e' to CI tests script

### DIFF
--- a/.script/test
+++ b/.script/test
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
 ETCDTESTDIR=".tmp/etcd-testdir"
 
 if [ ! -d ".tmp" ]; then

--- a/op/projected_gradient_test.go
+++ b/op/projected_gradient_test.go
@@ -27,7 +27,7 @@ func TestPGMinimize0(t *testing.T) {
 	proj := &Projection{lower_bound: lower, upper_bound: upper}
 	minimizer := &ProjectedGradient{projector: proj, beta: 0.1, sigma: 0.01, alpha: 1.0}
 	loss := &Rosenbrock{numOfCopies: copy, count: 0}
-	stpCount := MakeFixCountStopCriteria(1200)
+	stpCount := MakeFixCountStopCriteria(1500)
 
 	stt0 := createParam(3.0, -2.0, copy)
 


### PR DESCRIPTION
Otherwise, failed tests are silently ignored.