### PR TITLE
linkTypeTopology

### DIFF
--- a/.script/dep.sh
+++ b/.script/dep.sh
@@ -9,5 +9,6 @@ go get -u golang.org/x/net/context
 go get -u google.golang.org/grpc
 go get -u github.com/golang/protobuf/proto
 go get -u github.com/Azure/azure-sdk-for-go/storage
+go get -u github.com/plutoshe/taskgraph
 
 

--- a/example/bwmf/bwmf/main.go
+++ b/example/bwmf/bwmf/main.go
@@ -57,8 +57,8 @@ func main() {
 			ConfBytes:  confData,
 		}
 		bootstrap.SetTaskBuilder(taskBuilder)
-		bootstrap.AddLinkage("parent", topoParent)
-		bootstrap.AddLinkage("children", topoChildren)
+		bootstrap.AddLinkage("Parents", topoParent)
+		bootstrap.AddLinkage("Children", topoChildren)
 		log.Println("Starting task..")
 		bootstrap.Start()
 	case "c":

--- a/example/bwmf/bwmf/main.go
+++ b/example/bwmf/bwmf/main.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"../../../controller"
-	"../../topo"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph/controller"
+	"github.com/plutoshe/taskgraph/topo"
 	"github.com/taskgraph/taskgraph/example/bwmf"
 	"github.com/taskgraph/taskgraph/filesystem"
 	"github.com/taskgraph/taskgraph/framework"

--- a/example/bwmf/bwmf/main.go
+++ b/example/bwmf/bwmf/main.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"../example/topo"
+	"../../../controller"
+	"../../topo"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph/controller"
 	"github.com/taskgraph/taskgraph/example/bwmf"
 	"github.com/taskgraph/taskgraph/filesystem"
 	"github.com/taskgraph/taskgraph/framework"

--- a/example/bwmf/bwmf/main.go
+++ b/example/bwmf/bwmf/main.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
+	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/taskgraph/taskgraph/controller"
 	"github.com/taskgraph/taskgraph/example/bwmf"
-	"github.com/taskgraph/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/filesystem"
 	"github.com/taskgraph/taskgraph/framework"
 )
@@ -46,7 +46,8 @@ func main() {
 	etcdUrls := strings.Split(*etcdUrlList, ",")
 	log.Println("etcd urls: ", etcdUrls)
 
-	topo := topo.NewFullTopology(uint64(*numTasks))
+	topoParent := topo.NewFullTopologyOfMaster(uint64(*numTasks))
+	topoChildren := topo.NewFullTopologyOfNeighbor(uint64(*numTasks))
 
 	switch *jobType {
 	case "t":
@@ -56,7 +57,8 @@ func main() {
 			ConfBytes:  confData,
 		}
 		bootstrap.SetTaskBuilder(taskBuilder)
-		bootstrap.SetTopology(topo)
+		bootstrap.AddLinkage("parent", topoParent)
+		bootstrap.AddLinkage("children", topoChildren)
 		log.Println("Starting task..")
 		bootstrap.Start()
 	case "c":

--- a/example/bwmf/bwmf_task.go
+++ b/example/bwmf/bwmf_task.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
+	"github.com/plutoshe/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/bwmf/proto"
 	"github.com/taskgraph/taskgraph/filesystem"
 	"github.com/taskgraph/taskgraph/op"

--- a/example/bwmf/bwmf_task.go
+++ b/example/bwmf/bwmf_task.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
-	"github.com/taskgraph/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/bwmf/proto"
 	"github.com/taskgraph/taskgraph/filesystem"
 	"github.com/taskgraph/taskgraph/op"
@@ -294,7 +294,7 @@ func (t *bwmfTask) doEnterEpoch(ctx context.Context, epoch uint64) {
 }
 
 func (t *bwmfTask) fetchShards(ctx context.Context, method string) {
-	peers := t.framework.GetTopology()["Neighbors"].GetNeighbors(epoch)
+	peers := t.framework.GetTopology()["Neighbors"].GetNeighbors(t.epoch)
 	for _, peer := range peers {
 		t.framework.DataRequest(ctx, peer, method, &pb.Request{})
 	}

--- a/example/bwmf/bwmf_task.go
+++ b/example/bwmf/bwmf_task.go
@@ -138,25 +138,25 @@ func (t *bwmfTask) initData() {
 func (t *bwmfTask) initOptUtil() {
 	if t.tShard == nil {
 		// XXX: Initialize it random and sparse.
-		t.tShard = &pb.MatrixShard {
-			M: t.dims.n,
-			N: t.dims.k,
-			Val: make([]float32, t.dims.n * t.dims.k),
+		t.tShard = &pb.MatrixShard{
+			M:   t.dims.n,
+			N:   t.dims.k,
+			Val: make([]float32, t.dims.n*t.dims.k),
 		}
-		for i := uint32(0); i < t.tShard.M * t.tShard.N; i++ {
+		for i := uint32(0); i < t.tShard.M*t.tShard.N; i++ {
 			t.tShard.Val[i] = rand.Float32()
 		}
 	}
 
 	if t.dShard == nil {
 		// XXX: Initial at 0.0.
-		t.dShard = &pb.MatrixShard {
-			M: t.dims.m,
-			N: t.dims.k,
-			Val: make([]float32, t.dims.m * t.dims.k),
+		t.dShard = &pb.MatrixShard{
+			M:   t.dims.m,
+			N:   t.dims.k,
+			Val: make([]float32, t.dims.m*t.dims.k),
 		}
 
-		for i := uint32(0); i < t.dShard.M * t.dShard.N; i++ {
+		for i := uint32(0); i < t.dShard.M*t.dShard.N; i++ {
 			t.dShard.Val[i] = rand.Float32()
 		}
 	}
@@ -294,7 +294,7 @@ func (t *bwmfTask) doEnterEpoch(ctx context.Context, epoch uint64) {
 }
 
 func (t *bwmfTask) fetchShards(ctx context.Context, method string) {
-	peers := t.framework.GetTopology().GetNeighbors("Neighbors", t.epoch)
+	peers := t.framework.GetTopology()["Neighbors"].GetNeighbors(epoch)
 	for _, peer := range peers {
 		t.framework.DataRequest(ctx, peer, method, &pb.Request{})
 	}

--- a/example/bwmf/bwmf_taskbuilder.go
+++ b/example/bwmf/bwmf_taskbuilder.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"../../../taskgraph"
+	"github.com/plutoshe/taskgraph"
 	"github.com/taskgraph/taskgraph/filesystem"
 )
 

--- a/example/bwmf/bwmf_taskbuilder.go
+++ b/example/bwmf/bwmf_taskbuilder.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/taskgraph/taskgraph"
+	"../../../taskgraph"
 	"github.com/taskgraph/taskgraph/filesystem"
 )
 

--- a/example/regression/demo/main.go
+++ b/example/regression/demo/main.go
@@ -39,8 +39,8 @@ func main() {
 		}
 		bootstrap.SetTaskBuilder(taskBuilder)
 
-		bootstrap.AddLinkage("parent" : topo.NewTreeTopologyOfParent(2, ntask))
-		bootstrap.AddLinkage("children" : topo.NewTreeTopologyOfChildren(2, ntask))
+		bootstrap.AddLinkage("Parents" : topo.NewTreeTopologyOfParent(2, ntask))
+		bootstrap.AddLinkage("Children" : topo.NewTreeTopologyOfChildren(2, ntask))
 		bootstrap.Start()
 	default:
 		log.Fatal("Please choose a type: (c) controller, (t) task")

--- a/example/regression/demo/main.go
+++ b/example/regression/demo/main.go
@@ -38,7 +38,9 @@ func main() {
 			MasterConfig:       map[string]string{"writefile": "result.txt"},
 		}
 		bootstrap.SetTaskBuilder(taskBuilder)
-		bootstrap.SetTopology(topo.NewTreeTopology(2, ntask))
+
+		bootstrap.AddLinkage("parent" : topo.NewTreeTopologyOfParent(2, ntask))
+		bootstrap.AddLinkage("children" : topo.NewTreeTopologyOfChildren(2, ntask))
 		bootstrap.Start()
 	default:
 		log.Fatal("Please choose a type: (c) controller, (t) task")

--- a/example/regression/demo/main.go
+++ b/example/regression/demo/main.go
@@ -6,9 +6,9 @@ import (
 	"net"
 
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph/controller"
+	"../../../controller"
 	"github.com/taskgraph/taskgraph/example/regression"
-	"github.com/taskgraph/taskgraph/example/topo"
+	"../../example/topo"
 	"github.com/taskgraph/taskgraph/framework"
 )
 

--- a/example/regression/demo/main.go
+++ b/example/regression/demo/main.go
@@ -6,9 +6,9 @@ import (
 	"net"
 
 	"github.com/coreos/go-etcd/etcd"
-	"../../../controller"
+	"github.com/plutoshe/taskgraph/controller"
 	"github.com/taskgraph/taskgraph/example/regression"
-	"../../example/topo"
+	"github.com/plutoshe/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/framework"
 )
 

--- a/example/regression/master.go
+++ b/example/regression/master.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strconv"
 
-	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
+	"github.com/plutoshe/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/example/regression/master.go
+++ b/example/regression/master.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strconv"
 
+	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
-	"github.com/taskgraph/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -103,7 +103,7 @@ func (t *dummyMaster) enterEpoch(ctx context.Context, epoch uint64) {
 
 	t.epoch = epoch
 	t.param.Value = int32(t.epoch)
-	for _, c := range t.framework.GetTopology()["Children"].GetNeighborst.epoch) {
+	for _, c := range t.framework.GetTopology()["Children"].GetNeighbors(epoch) {
 		t.framework.DataRequest(ctx, c, "/proto.Regression/GetGradient", &pb.Input{})
 	}
 }

--- a/example/regression/master.go
+++ b/example/regression/master.go
@@ -103,7 +103,7 @@ func (t *dummyMaster) enterEpoch(ctx context.Context, epoch uint64) {
 
 	t.epoch = epoch
 	t.param.Value = int32(t.epoch)
-	for _, c := range t.framework.GetTopology().GetNeighbors("Children", t.epoch) {
+	for _, c := range t.framework.GetTopology()["Children"].GetNeighborst.epoch) {
 		t.framework.DataRequest(ctx, c, "/proto.Regression/GetGradient", &pb.Input{})
 	}
 }
@@ -158,7 +158,7 @@ func (t *dummyMaster) ChildDataReady(ctx context.Context, childID uint64, output
 	// This is a weak form of checking. We can also check the task ids.
 	// But this really means that we get all the events from children, we
 	// should go into the next epoch now.
-	if len(t.fromChildren) == len(t.framework.GetTopology().GetNeighbors("Children", t.epoch)) {
+	if len(t.fromChildren) == len(t.framework.GetTopology()["Children"].GetNeighbors(t.epoch)) {
 		t.gradient = new(pb.Gradient)
 		for _, g := range t.fromChildren {
 			t.gradient.Value += g.Value

--- a/example/regression/regression.go
+++ b/example/regression/regression.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 
-	"../../../taskgraph"
+	"github.com/plutoshe/taskgraph"
 )
 
 /*

--- a/example/regression/regression.go
+++ b/example/regression/regression.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 
-	"github.com/taskgraph/taskgraph"
+	"../../../taskgraph"
 )
 
 /*

--- a/example/regression/slave.go
+++ b/example/regression/slave.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
+	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
-	"github.com/taskgraph/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/example/regression/slave.go
+++ b/example/regression/slave.go
@@ -120,10 +120,10 @@ func (t *dummySlave) enterEpoch(ctx context.Context, epoch uint64) {
 	t.fromChildren = make(map[uint64]*pb.Gradient)
 	t.epoch = epoch
 
-	parent := t.framework.GetTopology().GetNeighbors("Parents", epoch)[0]
+	parent := t.framework.GetTopology()["Parents"].GetNeighbors(epoch)[0]
 	t.framework.DataRequest(ctx, parent, "/proto.Regression/GetParameter", &pb.Input{})
 
-	for _, c := range t.framework.GetTopology().GetNeighbors("Children", t.epoch) {
+	for _, c := range t.framework.GetTopology()["Children"].GetNeighbors(t.epoch) {
 		t.framework.DataRequest(ctx, c, "/proto.Regression/GetGradient", &pb.Input{})
 	}
 }
@@ -177,7 +177,7 @@ func (t *dummySlave) gradientReady(ctx context.Context) {
 	}
 }
 func (t *dummySlave) checkGradReady(ctx context.Context) {
-	children := t.framework.GetTopology().GetNeighbors("Children", t.epoch)
+	children := t.framework.GetTopology()["Children"].GetNeighbors(t.epoch)
 	if t.param != nil && len(t.fromChildren) == len(children) {
 		t.gradient = new(pb.Gradient)
 		t.gradient.Value = t.param.Value * int32(t.taskID)

--- a/example/regression/slave.go
+++ b/example/regression/slave.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"../../../taskgraph"
 	"github.com/golang/protobuf/proto"
+	"github.com/plutoshe/taskgraph"
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/example/topo/full_topo_master.go
+++ b/example/topo/full_topo_master.go
@@ -12,7 +12,7 @@ type FullTopologyOfMaster struct {
 
 // TODO, do we really need to expose this? Ideally after proper construction of StarTopology
 // we should not need to set this again.
-func (t *FullTopology) SetTaskID(taskID uint64) {
+func (t *FullTopologyOfMaster) SetTaskID(taskID uint64) {
 	t.all = make([]uint64, 0, t.numOfTasks)
 	t.taskID = taskID
 	for index := uint64(0); index < t.numOfTasks; index++ {
@@ -20,7 +20,7 @@ func (t *FullTopology) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *FullTopologyOfMaster) GetNeighbors(linkType string, epoch uint64) []uint64 {
 	res := make([]uint64, 0)
 	if t.taskID == 0 {
 		res = t.all
@@ -30,8 +30,8 @@ func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
 
 // Creates a new tree topology with given fanout and number of tasks.
 // This will be called during the task graph configuration.
-func NewFullTopologyOfMaster(nTasks uint64) *FullTopology {
-	return &FullTopology{
+func NewFullTopologyOfMaster(nTasks uint64) *FullTopologyOfMaster {
+	return &FullTopologyOfMaster{
 		numOfTasks: nTasks,
 	}
 }

--- a/example/topo/full_topo_master.go
+++ b/example/topo/full_topo_master.go
@@ -20,7 +20,7 @@ func (t *FullTopologyOfMaster) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *FullTopologyOfMaster) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *FullTopologyOfMaster) GetNeighbors(epoch uint64) []uint64 {
 	res := make([]uint64, 0)
 	if t.taskID == 0 {
 		res = t.all

--- a/example/topo/full_topo_master.go
+++ b/example/topo/full_topo_master.go
@@ -1,0 +1,37 @@
+package topo
+
+//The full structure is basically assume that every one is also parent for every else.
+//And everyone else is communicating to get the data they need. Task 0 is forced/assumed to be the master.
+//
+//Also the star structure stays the same between epochs.
+type FullTopologyOfMaster struct {
+	numOfTasks uint64
+	taskID     uint64
+	all        []uint64
+}
+
+// TODO, do we really need to expose this? Ideally after proper construction of StarTopology
+// we should not need to set this again.
+func (t *FullTopology) SetTaskID(taskID uint64) {
+	t.all = make([]uint64, 0, t.numOfTasks)
+	t.taskID = taskID
+	for index := uint64(0); index < t.numOfTasks; index++ {
+		t.all = append(t.all, index)
+	}
+}
+
+func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+	res := make([]uint64, 0)
+	if t.taskID == 0 {
+		res = t.all
+	}
+	return res
+}
+
+// Creates a new tree topology with given fanout and number of tasks.
+// This will be called during the task graph configuration.
+func NewFullTopologyOfMaster(nTasks uint64) *FullTopology {
+	return &FullTopology{
+		numOfTasks: nTasks,
+	}
+}

--- a/example/topo/full_topo_neighbor.go
+++ b/example/topo/full_topo_neighbor.go
@@ -20,7 +20,7 @@ func (t *FullTopologyOfNegihbor) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *FullTopologyOfNegihbor) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *FullTopologyOfNegihbor) GetNeighbors(epoch uint64) []uint64 {
 	res := make([]uint64, 0)
 	res = t.all
 	return res

--- a/example/topo/full_topo_neighbor.go
+++ b/example/topo/full_topo_neighbor.go
@@ -12,7 +12,7 @@ type FullTopologyOfNegihbor struct {
 
 // TODO, do we really need to expose this? Ideally after proper construction of StarTopology
 // we should not need to set this again.
-func (t *FullTopology) SetTaskID(taskID uint64) {
+func (t *FullTopologyOfNegihbor) SetTaskID(taskID uint64) {
 	t.all = make([]uint64, 0, t.numOfTasks)
 	t.taskID = taskID
 	for index := uint64(0); index < t.numOfTasks; index++ {
@@ -20,7 +20,7 @@ func (t *FullTopology) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *FullTopologyOfNegihbor) GetNeighbors(linkType string, epoch uint64) []uint64 {
 	res := make([]uint64, 0)
 	res = t.all
 	return res
@@ -28,8 +28,8 @@ func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
 
 // Creates a new tree topology with given fanout and number of tasks.
 // This will be called during the task graph configuration.
-func NewFullTopologyOfNeighbor(nTasks uint64) *FullTopology {
-	return &FullTopology{
+func NewFullTopologyOfNeighbor(nTasks uint64) *FullTopologyOfNegihbor {
+	return &FullTopologyOfNegihbor{
 		numOfTasks: nTasks,
 	}
 }

--- a/example/topo/full_topo_neighbor.go
+++ b/example/topo/full_topo_neighbor.go
@@ -1,0 +1,35 @@
+package topo
+
+//The full structure is basically assume that every one is also parent for every else.
+//And everyone else is communicating to get the data they need. Task 0 is forced/assumed to be the master.
+//
+//Also the star structure stays the same between epochs.
+type FullTopologyOfNegihbor struct {
+	numOfTasks uint64
+	taskID     uint64
+	all        []uint64
+}
+
+// TODO, do we really need to expose this? Ideally after proper construction of StarTopology
+// we should not need to set this again.
+func (t *FullTopology) SetTaskID(taskID uint64) {
+	t.all = make([]uint64, 0, t.numOfTasks)
+	t.taskID = taskID
+	for index := uint64(0); index < t.numOfTasks; index++ {
+		t.all = append(t.all, index)
+	}
+}
+
+func (t *FullTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+	res := make([]uint64, 0)
+	res = t.all
+	return res
+}
+
+// Creates a new tree topology with given fanout and number of tasks.
+// This will be called during the task graph configuration.
+func NewFullTopologyOfNeighbor(nTasks uint64) *FullTopology {
+	return &FullTopology{
+		numOfTasks: nTasks,
+	}
+}

--- a/example/topo/tree_topo_children.go
+++ b/example/topo/tree_topo_children.go
@@ -1,0 +1,37 @@
+package topo
+
+//The tree structure is basically assume that all the task forms a tree.
+//Also the tree structure stays the same between epochs.
+type TreeTopologyOfChildren struct {
+	fanout, numOfTasks uint64
+	taskID             uint64
+	children           []uint64
+}
+
+func (t *TreeTopology) SetTaskID(taskID uint64) {
+	t.taskID = taskID
+	// Not the most efficient way to create parents and children, but
+	// since this is not on critical path, we are ok.
+	t.children = make([]uint64, 0, t.fanout)
+
+	for index := uint64(1); index < t.numOfTasks; index++ {
+		parentID := (index - 1) / t.fanout
+		if parentID == taskID {
+			t.children = append(t.children, index)
+		}
+	}
+}
+
+func (t *TreeTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+	return t.children
+}
+
+// Creates a new tree topology with given fanout and number of tasks.
+// This will be called during the task graph configuration.
+func NewTreeTopologyOfChildren(fanout, nTasks uint64) *TreeTopology {
+	m := &TreeTopology{
+		fanout:     fanout,
+		numOfTasks: nTasks,
+	}
+	return m
+}

--- a/example/topo/tree_topo_children.go
+++ b/example/topo/tree_topo_children.go
@@ -22,7 +22,7 @@ func (t *TreeTopologyOfChildren) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *TreeTopologyOfChildren) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *TreeTopologyOfChildren) GetNeighbors(epoch uint64) []uint64 {
 	return t.children
 }
 

--- a/example/topo/tree_topo_children.go
+++ b/example/topo/tree_topo_children.go
@@ -8,7 +8,7 @@ type TreeTopologyOfChildren struct {
 	children           []uint64
 }
 
-func (t *TreeTopology) SetTaskID(taskID uint64) {
+func (t *TreeTopologyOfChildren) SetTaskID(taskID uint64) {
 	t.taskID = taskID
 	// Not the most efficient way to create parents and children, but
 	// since this is not on critical path, we are ok.
@@ -22,14 +22,14 @@ func (t *TreeTopology) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *TreeTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *TreeTopologyOfChildren) GetNeighbors(linkType string, epoch uint64) []uint64 {
 	return t.children
 }
 
 // Creates a new tree topology with given fanout and number of tasks.
 // This will be called during the task graph configuration.
-func NewTreeTopologyOfChildren(fanout, nTasks uint64) *TreeTopology {
-	m := &TreeTopology{
+func NewTreeTopologyOfChildren(fanout, nTasks uint64) *TreeTopologyOfChildren {
+	m := &TreeTopologyOfChildren{
 		fanout:     fanout,
 		numOfTasks: nTasks,
 	}

--- a/example/topo/tree_topo_parent.go
+++ b/example/topo/tree_topo_parent.go
@@ -2,13 +2,13 @@ package topo
 
 //The tree structure is basically assume that all the task forms a tree.
 //Also the tree structure stays the same between epochs.
-type TreeTopologyOfParents struct {
+type TreeTopologyOfParent struct {
 	fanout, numOfTasks uint64
 	taskID             uint64
 	parent             []uint64
 }
 
-func (t *TreeTopologyOfParents) SetTaskID(taskID uint64) {
+func (t *TreeTopologyOfParent) SetTaskID(taskID uint64) {
 	t.taskID = taskID
 	// Not the most efficient way to create parents and children, but
 	// since this is not on critical path, we are ok.
@@ -25,14 +25,14 @@ func (t *TreeTopologyOfParents) SetTaskID(taskID uint64) {
 	}
 }
 
-func (t *TreeTopologyOfParents) GetNeighbors(linkType string, epoch uint64) []uint64 {
+func (t *TreeTopologyOfParent) GetNeighbors(epoch uint64) []uint64 {
 	return t.parent
 }
 
 // Creates a new tree topology with given fanout and number of tasks.
 // This will be called during the task graph configuration.
-func NewTreeTopologyOfParents(fanout, nTasks uint64) *TreeTopologyOfParents {
-	m := &TreeTopologyOfParents{
+func NewTreeTopologyOfParent(fanout, nTasks uint64) *TreeTopologyOfParent {
+	m := &TreeTopologyOfParent{
 		fanout:     fanout,
 		numOfTasks: nTasks,
 	}

--- a/example/topo/tree_topo_parent.go
+++ b/example/topo/tree_topo_parent.go
@@ -5,34 +5,34 @@ package topo
 type TreeTopologyOfParents struct {
 	fanout, numOfTasks uint64
 	taskID             uint64
-	neighbor           []uint64
+	parent             []uint64
 }
 
-func (t *TreeTopology) SetTaskID(taskID uint64) {
+func (t *TreeTopologyOfParents) SetTaskID(taskID uint64) {
 	t.taskID = taskID
 	// Not the most efficient way to create parents and children, but
 	// since this is not on critical path, we are ok.
-	t.parents = make([]uint64, 0, 1)
+	t.parent = make([]uint64, 0, 1)
 
 	for index := uint64(1); index < t.numOfTasks; index++ {
 		parentID := (index - 1) / t.fanout
 		if index == taskID {
-			t.parents = append(t.parents, parentID)
-			if len(t.parents) > 1 {
+			t.parent = append(t.parent, parentID)
+			if len(t.parent) > 1 {
 				panic("unexpcted number of partents for a tree topology")
 			}
 		}
 	}
 }
 
-func (t *TreeTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
-	return t.parents
+func (t *TreeTopologyOfParents) GetNeighbors(linkType string, epoch uint64) []uint64 {
+	return t.parent
 }
 
 // Creates a new tree topology with given fanout and number of tasks.
 // This will be called during the task graph configuration.
-func NewTreeTopologyOfParents(fanout, nTasks uint64) *TreeTopology {
-	m := &TreeTopology{
+func NewTreeTopologyOfParents(fanout, nTasks uint64) *TreeTopologyOfParents {
+	m := &TreeTopologyOfParents{
 		fanout:     fanout,
 		numOfTasks: nTasks,
 	}

--- a/example/topo/tree_topo_parent.go
+++ b/example/topo/tree_topo_parent.go
@@ -1,0 +1,40 @@
+package topo
+
+//The tree structure is basically assume that all the task forms a tree.
+//Also the tree structure stays the same between epochs.
+type TreeTopologyOfParents struct {
+	fanout, numOfTasks uint64
+	taskID             uint64
+	neighbor           []uint64
+}
+
+func (t *TreeTopology) SetTaskID(taskID uint64) {
+	t.taskID = taskID
+	// Not the most efficient way to create parents and children, but
+	// since this is not on critical path, we are ok.
+	t.parents = make([]uint64, 0, 1)
+
+	for index := uint64(1); index < t.numOfTasks; index++ {
+		parentID := (index - 1) / t.fanout
+		if index == taskID {
+			t.parents = append(t.parents, parentID)
+			if len(t.parents) > 1 {
+				panic("unexpcted number of partents for a tree topology")
+			}
+		}
+	}
+}
+
+func (t *TreeTopology) GetNeighbors(linkType string, epoch uint64) []uint64 {
+	return t.parents
+}
+
+// Creates a new tree topology with given fanout and number of tasks.
+// This will be called during the task graph configuration.
+func NewTreeTopologyOfParents(fanout, nTasks uint64) *TreeTopology {
+	m := &TreeTopology{
+		fanout:     fanout,
+		numOfTasks: nTasks,
+	}
+	return m
+}

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"../../taskgraph"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/pkg/etcdutil"
 	"golang.org/x/net/context"
 )

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -30,6 +30,9 @@ func (f *framework) SetTaskBuilder(taskBuilder taskgraph.TaskBuilder) {
 
 //The user add their topology link to the original topology by this function
 func (f *framework) AddLinkage(linkType string, topology taskgraph.Topology) {
+	if f.topology == nil {
+		f.topology = make(map[string]taskgraph.Topology)
+	}
 	f.topology[linkType] = topology
 }
 

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -145,8 +145,8 @@ func (f *framework) setEpochStarted() {
 
 	f.task.EnterEpoch(f.userCtx, f.epoch)
 	// setup etcd watches
-	for _, linkType := range f.topology.GetLinkTypes() {
-		f.watchMeta(linkType, f.topology.GetNeighbors(linkType, f.epoch))
+	for linkType, _ := range f.topology {
+		f.watchMeta(linkType, f.topology[linkType].GetNeighbors(f.epoch))
 	}
 }
 

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -28,7 +28,9 @@ func (f *framework) SetTaskBuilder(taskBuilder taskgraph.TaskBuilder) {
 	f.taskBuilder = taskBuilder
 }
 
-func (f *framework) SetTopology(topology taskgraph.Topology) { f.topology = topology }
+func (f *framework) AddLinkage(topology taskgraph.Topology) {
+	f.topology[topology.GetLinkType()] = topology
+}
 
 func (f *framework) Start() {
 	var err error
@@ -63,7 +65,9 @@ func (f *framework) Start() {
 	// Both should be initialized at this point.
 	// Get the task implementation and topology for this node (indentified by taskID)
 	f.task = f.taskBuilder.GetTask(f.taskID)
-	f.topology.SetTaskID(f.taskID)
+	for key, _ := range f.topology {
+		f.topology[key].SetTaskID(f.taskID)
+	}
 
 	f.heartbeat()
 	f.setup()

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -28,8 +28,9 @@ func (f *framework) SetTaskBuilder(taskBuilder taskgraph.TaskBuilder) {
 	f.taskBuilder = taskBuilder
 }
 
-func (f *framework) AddLinkage(topology taskgraph.Topology) {
-	f.topology[topology.GetLinkType()] = topology
+//The user add their topology link to the original topology by this function
+func (f *framework) AddLinkage(linkType string, topology taskgraph.Topology) {
+	f.topology[linkType] = topology
 }
 
 func (f *framework) Start() {

--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"../../taskgraph"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph"
 	"github.com/taskgraph/taskgraph/pkg/etcdutil"
 	"golang.org/x/net/context"
 )

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -22,7 +22,7 @@ type framework struct {
 
 	// user defined interfaces
 	taskBuilder taskgraph.TaskBuilder
-	topology    taskgraph.Topology
+	topology    map[string]taskgraph.Topology
 
 	task          taskgraph.Task
 	taskID        uint64

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"net"
 
+	"../../taskgraph"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/pkg/etcdutil"
 	"golang.org/x/net/context"
 )

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"net"
 
-	"../../taskgraph"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph"
 	"github.com/taskgraph/taskgraph/pkg/etcdutil"
 	"golang.org/x/net/context"
 )

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -88,7 +88,7 @@ func (f *framework) IncEpoch(ctx context.Context) {
 	}
 }
 
-func (f *framework) GetTopology() taskgraph.Topology { return f.topology }
+func (f *framework) GetTopology() map[string]taskgraph.Topology { return f.topology }
 
 func (f *framework) Kill() {
 	// framework select loop will quit and end like getting a exit epoch, except that

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"testing"
 
-	"../../taskgraph"
-	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/protobuf/proto"
+	"github.com/plutoshe/taskgraph"
+	"github.com/plutoshe/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/controller"
 
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"testing"
 
+	"../../taskgraph"
 	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/protobuf/proto"
-	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/controller"
 
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
@@ -39,8 +39,8 @@ func TestRequestDataEpochMismatch(t *testing.T) {
 	fw.SetTaskBuilder(&testableTaskBuilder{
 		setupLatch: &wg,
 	})
-	fw.AddLinkage("parent", topo.NewTreeTopologyOfParent(1, 1))
-	fw.AddLinkage("children", topo.NewTreeTopologyOfChildren(1, 1))
+	fw.AddLinkage("Parents", topo.NewTreeTopologyOfParent(1, 1))
+	fw.AddLinkage("Children", topo.NewTreeTopologyOfChildren(1, 1))
 	wg.Add(1)
 	go fw.Start()
 	wg.Wait()
@@ -96,11 +96,11 @@ func TestFrameworkFlagMetaReady(t *testing.T) {
 		setupLatch: &wg,
 	}
 	f0.SetTaskBuilder(taskBuilder)
-	f0.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
-	f0.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
+	f0.AddLinkage("Parents", topo.NewTreeTopologyOfParent(2, 2))
+	f0.AddLinkage("Children", topo.NewTreeTopologyOfChildren(2, 2))
 	f1.SetTaskBuilder(taskBuilder)
-	f1.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
-	f1.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
+	f1.AddLinkage("Parents", topo.NewTreeTopologyOfParent(2, 2))
+	f1.AddLinkage("Children", topo.NewTreeTopologyOfChildren(2, 2))
 
 	taskBuilder.setupLatch.Add(2)
 	go f0.Start()
@@ -174,11 +174,11 @@ func TestFrameworkDataRequest(t *testing.T) {
 		setupLatch: &wg,
 	}
 	f0.SetTaskBuilder(taskBuilder)
-	f0.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
-	f0.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
+	f0.AddLinkage("Parents", topo.NewTreeTopologyOfParent(2, 2))
+	f0.AddLinkage("Children", topo.NewTreeTopologyOfChildren(2, 2))
 	f1.SetTaskBuilder(taskBuilder)
-	f1.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
-	f1.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
+	f1.AddLinkage("Parents", topo.NewTreeTopologyOfParent(2, 2))
+	f1.AddLinkage("Children", topo.NewTreeTopologyOfChildren(2, 2))
 
 	taskBuilder.setupLatch.Add(2)
 	go f0.Start()

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -39,7 +39,8 @@ func TestRequestDataEpochMismatch(t *testing.T) {
 	fw.SetTaskBuilder(&testableTaskBuilder{
 		setupLatch: &wg,
 	})
-	fw.SetTopology(topo.NewTreeTopology(1, 1))
+	fw.AddLinkage("parent", topo.NewTreeTopologyOfParent(1, 1))
+	fw.AddLinkage("children", topo.NewTreeTopologyOfChildren(1, 1))
 	wg.Add(1)
 	go fw.Start()
 	wg.Wait()
@@ -95,9 +96,11 @@ func TestFrameworkFlagMetaReady(t *testing.T) {
 		setupLatch: &wg,
 	}
 	f0.SetTaskBuilder(taskBuilder)
-	f0.SetTopology(topo.NewTreeTopology(2, 2))
+	f0.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
+	f0.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
 	f1.SetTaskBuilder(taskBuilder)
-	f1.SetTopology(topo.NewTreeTopology(2, 2))
+	f1.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
+	f1.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
 
 	taskBuilder.setupLatch.Add(2)
 	go f0.Start()
@@ -171,9 +174,11 @@ func TestFrameworkDataRequest(t *testing.T) {
 		setupLatch: &wg,
 	}
 	f0.SetTaskBuilder(taskBuilder)
-	f0.SetTopology(topo.NewTreeTopology(2, 2))
+	f0.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
+	f0.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
 	f1.SetTaskBuilder(taskBuilder)
-	f1.SetTopology(topo.NewTreeTopology(2, 2))
+	f1.AddLinkage("parent", topo.NewTreeTopologyOfParent(2, 2))
+	f1.AddLinkage("children", topo.NewTreeTopologyOfChildren(2, 2))
 
 	taskBuilder.setupLatch.Add(2)
 	go f0.Start()

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 	"testing"
 
+	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/protobuf/proto"
 	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/controller"
-	"github.com/taskgraph/taskgraph/example/topo"
 
 	pb "github.com/taskgraph/taskgraph/example/regression/proto"
 	"github.com/taskgraph/taskgraph/pkg/etcdutil"

--- a/framework_interface.go
+++ b/framework_interface.go
@@ -25,7 +25,7 @@ type Bootstrap interface {
 // high level features.
 type Framework interface {
 	// This allow the task implementation query its neighbors.
-	GetTopology() Topology
+	GetTopology() map[string]Topology
 
 	// Kill the framework itself.
 	// As epoch changes, some nodes isn't needed anymore

--- a/framework_interface.go
+++ b/framework_interface.go
@@ -14,7 +14,7 @@ type Bootstrap interface {
 	SetTaskBuilder(taskBuilder TaskBuilder)
 
 	// This allow the application to specify how tasks are connection at each epoch
-	SetTopology(topology Topology)
+	AddLinkage(linkType string, topology Topology)
 
 	// After all the configure is done, driver need to call start so that all
 	// nodes will get into the event loop to run the application.

--- a/integration/bwmf_test.go
+++ b/integration/bwmf_test.go
@@ -3,10 +3,10 @@ package integration
 import (
 	"testing"
 
-	"../../taskgraph"
-	"../example/bwmf"
-	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph"
+	"github.com/plutoshe/taskgraph/example/bwmf"
+	"github.com/plutoshe/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/controller"
 	pb "github.com/taskgraph/taskgraph/example/bwmf/proto"
 	"github.com/taskgraph/taskgraph/filesystem"

--- a/integration/bwmf_test.go
+++ b/integration/bwmf_test.go
@@ -44,7 +44,16 @@ func TestBWMF(t *testing.T) {
 				}`),
 	}
 	for i := uint64(0); i < numOfTasks; i++ {
-		go drive(t, job, etcdURLs, tb, topo.NewFullTopology(numOfTasks))
+		go drive(
+			t, 
+			job, 
+			etcdURLs, 
+			tb, 
+			map[string]int{
+    			"master" : topo.NewFullTopologyOfMaster(numOfTasks))
+				"neighbor" : topo.NewFullTopologyOfNeighbor(numOfTasks)
+			}
+		)
 	}
 
 	ctl.WaitForJobDone()

--- a/integration/bwmf_test.go
+++ b/integration/bwmf_test.go
@@ -3,12 +3,12 @@ package integration
 import (
 	"testing"
 
+	"../../taskgraph"
+	"../example/bwmf"
+	"../example/topo"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/controller"
-	"github.com/taskgraph/taskgraph/example/bwmf"
 	pb "github.com/taskgraph/taskgraph/example/bwmf/proto"
-	"github.com/taskgraph/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/filesystem"
 )
 

--- a/integration/bwmf_test.go
+++ b/integration/bwmf_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/taskgraph/taskgraph"
 	"github.com/taskgraph/taskgraph/controller"
 	"github.com/taskgraph/taskgraph/example/bwmf"
 	pb "github.com/taskgraph/taskgraph/example/bwmf/proto"
@@ -45,14 +46,14 @@ func TestBWMF(t *testing.T) {
 	}
 	for i := uint64(0); i < numOfTasks; i++ {
 		go drive(
-			t, 
-			job, 
-			etcdURLs, 
-			tb, 
-			map[string]int{
-    			"master" : topo.NewFullTopologyOfMaster(numOfTasks))
-				"neighbor" : topo.NewFullTopologyOfNeighbor(numOfTasks)
-			}
+			t,
+			job,
+			etcdURLs,
+			tb,
+			map[string]taskgraph.Topology{
+				"Master":    topo.NewFullTopologyOfMaster(numOfTasks),
+				"Neighbors": topo.NewFullTopologyOfNeighbor(numOfTasks),
+			},
 		)
 	}
 
@@ -98,41 +99,41 @@ func getShards() (row0, column0, row1, column1 *pb.MatrixShard) {
 	// shard0: row 0,1 of A
 	rowShard0 := &pb.MatrixShard{
 		IsSparse: true,
-		M: 2,
-		N: 4,
-		Val: []float32 {0.42, 0.30, 0.30, 0.34, 0.10, 0.70, 1.00},
-		Ir: []uint32 {0, 1, 0, 0, 1, 0, 1},
-		Jc: []uint32 {0, 2, 3, 5, 7},
+		M:        2,
+		N:        4,
+		Val:      []float32{0.42, 0.30, 0.30, 0.34, 0.10, 0.70, 1.00},
+		Ir:       []uint32{0, 1, 0, 0, 1, 0, 1},
+		Jc:       []uint32{0, 2, 3, 5, 7},
 	}
 
 	// shard0: column 0,1 of A
 	columnShard0 := &pb.MatrixShard{
 		IsSparse: true,
-		M: 2,
-		N: 3,
-		Val: []float32 {0.42, 0.30, 0.30, 0.70, 1.00},
-		Ir: []uint32 {0, 1, 0, 0, 1},
-		Jc: []uint32 {0, 2, 3, 5},
+		M:        2,
+		N:        3,
+		Val:      []float32{0.42, 0.30, 0.30, 0.70, 1.00},
+		Ir:       []uint32{0, 1, 0, 0, 1},
+		Jc:       []uint32{0, 2, 3, 5},
 	}
 
 	// shard1: row 1 of A
 	rowShard1 := &pb.MatrixShard{
 		IsSparse: true,
-		M: 1,
-		N: 4,
-		Val: []float32 {0.70, 1.00, 0.90},
-		Ir: []uint32 {0, 0, 0},
-		Jc: []uint32 {0, 1, 2, 3, 3},
+		M:        1,
+		N:        4,
+		Val:      []float32{0.70, 1.00, 0.90},
+		Ir:       []uint32{0, 0, 0},
+		Jc:       []uint32{0, 1, 2, 3, 3},
 	}
 
 	// shard1: column 2,3 of A
 	columnShard1 := &pb.MatrixShard{
 		IsSparse: true,
-		M: 2,
-		N: 3,
-		Val: []float32 {0.34, 0.70, 0.10, 1.00, 0.90},
-		Ir: []uint32 {0, 1, 0, 1, 0},
-		Jc: []uint32 {0, 2, 4, 5},
+		M:        2,
+		N:        3,
+		Val:      []float32{0.34, 0.70, 0.10, 1.00, 0.90},
+		Ir:       []uint32{0, 1, 0, 1, 0},
+		Jc:       []uint32{0, 2, 4, 5},
 	}
 
 	return rowShard0, columnShard0, rowShard1, columnShard1

--- a/integration/common.go
+++ b/integration/common.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/taskgraph/taskgraph"
+	"../../taskgraph"
 	"github.com/taskgraph/taskgraph/example/topo"
 	"github.com/taskgraph/taskgraph/framework"
 )
@@ -19,13 +19,24 @@ func createListener(t *testing.T) net.Listener {
 
 // This is used to show how to drive the network.
 func driveWithTreeTopo(t *testing.T, jobName string, etcds []string, ntask uint64, taskBuilder taskgraph.TaskBuilder) {
-	drive(t, jobName, etcds, taskBuilder, topo.NewTreeTopology(2, ntask))
+	drive(
+		t, 
+		jobName, 
+		etcds, 
+		taskBuilder, 
+		map[string]int{
+			"parent" : topo.NewTreeTopologyOfParent(numOfTasks))
+			"children" : topo.NewTreeTopologyOfNeighbor(numOfTasks)
+		}
+	)
 }
 
-func drive(t *testing.T, jobName string, etcds []string, taskBuilder taskgraph.TaskBuilder, topo taskgraph.Topology) {
+func drive(t *testing.T, jobName string, etcds []string, taskBuilder taskgraph.TaskBuilder, topo map[string]taskgraph.Topology) {
 
 	bootstrap := framework.NewBootStrap(jobName, etcds, createListener(t), nil)
 	bootstrap.SetTaskBuilder(taskBuilder)
-	bootstrap.SetTopology(topo)
+	for i, _ := range topo {
+		bootstrap.AddLinkage(i, topo[i])
+	}
 	bootstrap.Start()
 }

--- a/integration/common.go
+++ b/integration/common.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"../../taskgraph"
-	"github.com/taskgraph/taskgraph/example/topo"
-	"github.com/taskgraph/taskgraph/framework"
+	"../example/topo"
+	"../framework"
 )
 
 func createListener(t *testing.T) net.Listener {
@@ -20,14 +20,14 @@ func createListener(t *testing.T) net.Listener {
 // This is used to show how to drive the network.
 func driveWithTreeTopo(t *testing.T, jobName string, etcds []string, ntask uint64, taskBuilder taskgraph.TaskBuilder) {
 	drive(
-		t, 
-		jobName, 
-		etcds, 
-		taskBuilder, 
-		map[string]int{
-			"parent" : topo.NewTreeTopologyOfParent(numOfTasks))
-			"children" : topo.NewTreeTopologyOfNeighbor(numOfTasks)
-		}
+		t,
+		jobName,
+		etcds,
+		taskBuilder,
+		map[string]taskgraph.Topology{
+			"Parents":  topo.NewTreeTopologyOfParent(2, ntask),
+			"Children": topo.NewTreeTopologyOfChildren(2, ntask),
+		},
 	)
 }
 

--- a/integration/common.go
+++ b/integration/common.go
@@ -4,9 +4,9 @@ import (
 	"net"
 	"testing"
 
-	"../../taskgraph"
-	"../example/topo"
-	"../framework"
+	"github.com/plutoshe/taskgraph"
+	"github.com/plutoshe/taskgraph/example/topo"
+	"github.com/plutoshe/taskgraph/framework"
 )
 
 func createListener(t *testing.T) net.Listener {

--- a/integration/node_failure_test.go
+++ b/integration/node_failure_test.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"testing"
 
-	"../controller"
-	"../example/regression"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph/controller"
+	"github.com/plutoshe/taskgraph/example/regression"
 )
 
 // TestMasterSetEpochFailure checks if a master task failed at SetEpoch,

--- a/integration/node_failure_test.go
+++ b/integration/node_failure_test.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"testing"
 
+	"../controller"
+	"../example/regression"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph/controller"
-	"github.com/taskgraph/taskgraph/example/regression"
 )
 
 // TestMasterSetEpochFailure checks if a master task failed at SetEpoch,

--- a/integration/regression_framework_test.go
+++ b/integration/regression_framework_test.go
@@ -3,9 +3,9 @@ package integration
 import (
 	"testing"
 
-	"../controller"
-	"../example/regression"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/plutoshe/taskgraph/controller"
+	"github.com/plutoshe/taskgraph/example/regression"
 )
 
 func TestRegressionFramework(t *testing.T) {

--- a/integration/regression_framework_test.go
+++ b/integration/regression_framework_test.go
@@ -3,9 +3,9 @@ package integration
 import (
 	"testing"
 
+	"../controller"
+	"../example/regression"
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/taskgraph/taskgraph/controller"
-	"github.com/taskgraph/taskgraph/example/regression"
 )
 
 func TestRegressionFramework(t *testing.T) {

--- a/topology_interface.go
+++ b/topology_interface.go
@@ -1,14 +1,21 @@
 /*
 The topology is a data structure implemented by application, and
 used by framework implementation to setup/manage the event according to
-topology defined here. The main usage is:
+a set of topology defined here.
+
+Each Topology describe a specific link in overall topology.
+For instance, a topology describe a master link, it will instruct
+the framework the master link of node in each epoch.
+
+The main usage is:
 a. At beginning of the framework initialization for each task, framework
    call the SetTaskID so that the singleton Topology knows which taskID it
    represents.
-b. At beginning of each epoch, the framework implementation (on each task)
-   will call GetLinkTypes and GetNeighbors with given epoch, so that it knows
-   how to setup watcher for node failures.
+b. At beginning of each epoch, the framework implementation call GetNeighbors
+   with given epoch, so that it knows how to set watcher for node failure
+   for specific relationship
 */
+
 package taskgraph
 
 // The Topology will be implemented by the application.
@@ -19,9 +26,6 @@ type Topology interface {
 	// we can get the local topology for each epoch later.
 	SetTaskID(taskID uint64)
 
-	// This returns the type of links this topology supports
-	GetLinkTypes() []string
-
 	// This returns the neighbors of given link for this node at this epoch.
-	GetNeighbors(linkType string, epoch uint64) []uint64
+	GetNeighbors(epoch uint64) []uint64
 }


### PR DESCRIPTION
Initial interface for linkTopology.
Substitute the topology with a set of linkTopology.
For instance, we describe a topology as a set of linkType, and corresponding sets of pointed linkType before. After changing to linkType, for every linkType, we describe as a topology.
It's more flexible to fit the latter structure.
