### PR TITLE
BWMF Global State Management: refactor epoch

### DIFF
--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -108,7 +108,7 @@ func (f *framework) run() {
 			// the epoch that was meant for this event. This context will be passed
 			// to user event handler functions and used to ask framework to do work later
 			// with previous information.
-			f.handleMetaChange(f.userCtx, meta.from, meta.linkType, meta.meta)
+			go f.handleMetaChange(f.userCtx, meta.from, meta.linkType, meta.meta)
 		case req := <-f.dataReqtoSendChan:
 			if req.epoch != f.epoch {
 				f.log.Printf("abort data request, to %d, epoch %d, method %s", req.taskID, req.epoch, req.method)
@@ -228,16 +228,5 @@ func (f *framework) watchMeta() {
 }
 
 func (f *framework) handleMetaChange(ctx context.Context, taskID uint64, linkType, meta string) {
-	// check if meta is handled before.
-	tm := taskMeta(taskID, meta)
-	if _, ok := f.metaNotified[tm]; ok {
-		return
-	}
-	f.metaNotified[tm] = true
-
 	f.task.MetaReady(ctx, taskID, linkType, meta)
-}
-
-func taskMeta(taskID uint64, meta string) string {
-	return fmt.Sprintf("%s-%s", strconv.FormatUint(taskID, 10), meta)
 }

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -34,7 +34,7 @@ type framework struct {
 
 	// A meta is a signal for specific epoch some task has some data.
 	// However, our fault tolerance mechanism will start another task if it failed
-	// and flag the same meta again. Therefore, we keep track of  notified meta.
+	// and flag the same meta again. Therefore, we keep track of notified meta.
 	metaNotified map[string]bool
 
 	// etcd stops


### PR DESCRIPTION
Our goal is remove epoch related API. There will be a couple of steps. The first one is to take out the epoch logic from framework epoch API and make this independent.

Here's a brief summary for the change. Let’s assume task 0 is the master.
* In EnterEpoch(), it will get the ctx object to flagmeta (“Neighbors”, “$(epoch)”) to all tasks. Every task will be called on MetaReady() and tell from linktype “Neighbors” and reuse the previous epochChange event handling logic.
* We also need to change IncEpoch to FlagMeta with an incremented epoch as meta.
* In Framework, I’m removing the metaNotified field because as we want to get rid of the exactly-once semantics.