### PR TITLE
WaitForJobDone() should wait until task fully finished

### DIFF
--- a/framework/bootstrap.go
+++ b/framework/bootstrap.go
@@ -81,6 +81,9 @@ func (f *framework) Start() {
 	f.run()
 	f.releaseResource()
 	f.task.Exit()
+	if err := etcdutil.SetJobStatus(f.etcdClient, f.name, 0); err != nil {
+		panic("SetJobStatus")
+	}
 }
 
 func (f *framework) setup() {

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -114,9 +114,6 @@ func (f *framework) ShutdownJob() {
 	if err := etcdutil.CASEpoch(f.etcdClient, f.name, f.epoch, exitEpoch); err != nil {
 		panic("TODO: we should do a set instead of CAS here.")
 	}
-	if err := etcdutil.SetJobStatus(f.etcdClient, f.name, 0); err != nil {
-		panic("SetJobStatus")
-	}
 }
 
 func (f *framework) GetLogger() *log.Logger { return f.log }


### PR DESCRIPTION
Controller.WaitForJobDone() watches JobStatus in etcd to determine when the task
job has finished.

Now, JobStatus is set in Framework.ShutdownJob() -- a function called by task
implementer to notify the framework its job has been done. After the notification,
the framework will then call Framework.releaseResource() and Task.Exit() to do
cleanup work. However, at this time point, the controler may have already
stopped (since it has seen the JobStatus change), and therefore causes the task
cleanup process to stop early.

After this patch, we set JobStatus only after the task cleanup process has been
done, in order to make sure it won't be wrongly stoped by controller.