### PR TITLE
Azure : Fix azure Remove container not exist bug

### DIFF
--- a/filesystem/azure.go
+++ b/filesystem/azure.go
@@ -66,9 +66,14 @@ func (c *AzureClient) Remove(name string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.blobClient.DeleteBlobIfExists(containerName, blobName)
+	exist, err := c.blobClient.ContainerExists(containerName)
+	if err != nil {
+		return err
+	}
+	if exist {
+		_, err = c.blobClient.DeleteBlobIfExists(containerName, blobName)
+	}
 	return err
-
 }
 
 // AzureClient -> Exist function


### PR DESCRIPTION
This commit fix a panic bug.
In old code, When container does not exist, it will panic when user
wants to remove the blob in a non-exist contianer.